### PR TITLE
Add server-specific functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ __%invite__: Generate a link that you can use to add goPC to your own server.
 
 __%create_roles__\*: Create three empty team roles that goPC can use to assign.
 
-__%stats__: List stats on the number of team members, including the percentage of the members on each team. Only works with the default Pokemon GO roles, if they exist on the server.
+__%stats__: List stats on the number of team members, including the percentage of the members on each team. Only works with the default Pokemon GO roles, if they exist on the server ("Mystic", "Instinct", and "Valor", case sensitive).
 
 __%wiki [page]__: Find a page on bulbapedia.
 

--- a/README.md
+++ b/README.md
@@ -23,33 +23,33 @@ to join Team Valor if it's enabled on the server. By default, the bot supports P
 
 * Ability to assign roles that aren't Pokemon GO roles, by adding them with `%enable_role` and then using `%team`.
 
-* Ability to let users assign either one role or multiple roles to themselves.
+* Ability to let users assign either one role or multiple roles to themselves, which can be changed with `%role_config`.
 
 # Current commands
 
 __%team [team name]__: Assign yourself to a team. Typed like `%team Mystic` to set your role as Team Mystic.
 
-__%whitelist__\*: Set a specific channel for team setting.
+__%whitelist__\*: Make %team only work in the channel(s) this is called in. Can be called in multiple channels, and it will redirect users trying to call %team in other channels to the whitelisted channels.
 
-__%unwhitelist__\*: Re-allow team setting in a channel.
+__%unwhitelist__\*: Remove the channel this is called in from the whitelist. If multiple channels are whitelisted, all channels need to be removed from the whitelist before you can call %team in other channels.
 
-__%server_info__: Output a small list of information about the server.
+__%server_info__: Output a small list of information about the current server.
 
-__%help or %commands__: Show this message again.
+__%help or %commands__: Show a list of commands.
 
-__%pm [required/optional]__\*: Optional is default, and required disables setting roles in the server.
+__%pm [required/optional]__\*: Optional is default, and lets you call %team in the server as well as PMs, while required disables setting roles in the server.
 
 __%invite__: Generate a link that you can use to add goPC to your own server.
 
 __%create_roles__\*: Create three empty team roles that goPC can use to assign.
 
-__%stats__: List stats on the number of team members, including the percentage of the members on each team. Only works with the default Pokemon GO roles.
+__%stats__: List stats on the number of team members, including the percentage of the members on each team. Only works with the default Pokemon GO roles, if they exist on the server.
 
 __%wiki [page]__: Find a page on bulbapedia.
 
-__%enable_role [role name]__\*: Allow a role to be added by goPC.
+__%enable_role [role name]__\*: Allow a role to be added with %team.
 
-__%disable_role [role name]__\*: Disallow a role from being added by goPC, if it already can be.
+__%disable_role [role name]__\*: Disallow a role from being added with %team, if it already can be.
 
 __%role_config [exclusive/multiple]__\*: Setting to exclusive (default) only allows one role to be set per user. Setting to multiple allows users to set as many roles as they want.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # goPC
 Multi-server role-assigning bot, similar to Bill's PC from the /r/PokemonGO discord, and written by `Luc | ルカリオ#5653`.
-The purpose of this bot is to make assigning team-based roles for Pokemon GO servers a breeze, and to provide to other, smaller servers the same sort of functionality that Bill's PC provides with its `%team` command.
+The original purpose of this bot is to make assigning team-based roles for Pokemon GO servers a breeze, and to provide to other, smaller servers the same sort of functionality that Bill's PC provides with its `%team` command. Its use cases aren't just limited to Pokemon GO servers, though, as goPC can be easily set up to assign other roles as well.
 Designed out of demand for a similar sort of solution in smaller servers, where users want a no-fuss solution that adds roles based on Pokemon GO teams. Designed to be light, and shouldn't really interfere with anything. Doesn't log anything, either.
 
 **You can easily add this bot to your server by clicking [this link](https://discordapp.com/oauth2/authorize?client_id=202615577041305600&scope=bot&permissions=268438528).**
@@ -10,22 +10,26 @@ If you want to use this bot's code and launch your own instance, *please please 
 
 # Current features:
 
-* Ability to add roles based on a simple command, `%team [team name]`, where team name is Instinct, Valor or Mystic.
+* Ability to add roles based on a simple command, `%team [team name]`, where team name is the name of the role you would like to assign.
 Users would, for example, type:
 `%team Valor`
-to join Team Valor. The server is required to have roles that correspond to the team name, and are formatted as shown above.
+to join Team Valor if it's enabled on the server. By default, the bot supports Pokemon GO team roles, if their names are formatted like `Valor`, `Instinct`, and `Mystic` (case sensitive).
 
 * Ability to whitelist certain channels for assigning %team.
 
 * Team requests can be sent through PMs, and have a selection menu if you share more than one server.
 
-* Ability to create a set of empty template roles (no permissions) that can then be configured manually, by using %create_roles with the `Manage Server` permission.
+* Ability to create a set of empty template roles (no permissions) that can then be configured manually, by using `%create_roles` with the `Manage Server` permission.
+
+* Ability to assign roles that aren't Pokemon GO roles, by adding them with `%enable_role` and then using `%team`.
+
+* Ability to let users assign either one role or multiple roles to themselves.
 
 # Current commands
 
 __%team [team name]__: Assign yourself to a team. Typed like `%team Mystic` to set your role as Team Mystic.
 
-__%whitelist\*__: Set a specific channel for team setting.
+__%whitelist__\*: Set a specific channel for team setting.
 
 __%unwhitelist__\*: Re-allow team setting in a channel.
 
@@ -39,9 +43,17 @@ __%invite__: Generate a link that you can use to add goPC to your own server.
 
 __%create_roles__\*: Create three empty team roles that goPC can use to assign.
 
-__%stats__: List stats on the number of team members, including the percentage of the members on each team.
+__%stats__: List stats on the number of team members, including the percentage of the members on each team. Only works with the default Pokemon GO roles.
 
 __%wiki [page]__: Find a page on bulbapedia.
+
+__%enable_role [role name]__\*: Allow a role to be added by goPC.
+
+__%disable_role [role name]__\*: Disallow a role from being added by goPC, if it already can be.
+
+__%role_config [exclusive/multiple]__\*: Setting to exclusive (default) only allows one role to be set per user. Setting to multiple allows users to set as many roles as they want.
+
+__%server_config__: Output the current server settings (whitelisted channels, role config setting, addable roles, and PM role-assignment settings).
 
 **Commands with an asterisk can only be run by the server owner or a user with the `Manage Server` permission.**
 
@@ -61,8 +73,6 @@ You can find this list by using %help or %oommands in chat.
 At the moment, I'm going to go for an early release with the sole functionality of adding team commands, but there are some features I'd like to implement in the future.
 
 * Aliases for team names.
-
-* Ability to use different role lists than just the Pokemon Go team list, so as to make the bot useful in other applications.
 
 * Perhaps adding some other commands that are a bit more fun. __This isn't really the intention of the bot, though, and I probably won't be adding many fun commands.__ So don't pester me about it, please. :P
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Users would, for example, type:
 `%team Valor`
 to join Team Valor if it's enabled on the server. By default, the bot supports Pokemon GO team roles, if their names are formatted like `Valor`, `Instinct`, and `Mystic` (case sensitive).
 
+* Ability to assign roles that aren't Pokemon GO roles, by adding them with `%enable_role` and then using `%team`.
+
 * Ability to whitelist certain channels for assigning %team.
 
 * Team requests can be sent through PMs, and have a selection menu if you share more than one server.
 
 * Ability to create a set of empty template roles (no permissions) that can then be configured manually, by using `%create_roles` with the `Manage Server` permission.
-
-* Ability to assign roles that aren't Pokemon GO roles, by adding them with `%enable_role` and then using `%team`.
 
 * Ability to let users assign either one role or multiple roles to themselves, which can be changed with `%role_config`.
 

--- a/bot.py
+++ b/bot.py
@@ -19,6 +19,8 @@ except IOError:
     auth = None  # Tired of pycharm pointing it out
     exit("auth.json not found in running directory.")
 
+# TODO: Better implement logging
+
 discord_logger = logging.getLogger('discord')
 discord_logger.setLevel(logging.CRITICAL)
 log = logging.getLogger()
@@ -297,6 +299,10 @@ async def on_message(message):
         member_count = sum(1 for _ in members)
         await client.send_message(message.channel, server_info_message.format(message.server, member_count))
 
+    elif message.content.startswith("%server_config"):
+        server_obj = bot.servers[message.server.id]
+        await client.send_message(message.channel, server_obj.generate_config_msg())
+
     # Generate an oauth link so people can add it to their own servers.
 
     elif message.content.startswith('%invite'):
@@ -368,13 +374,6 @@ async def on_message(message):
         if not server_obj.exists_default_roles():
             await client.send_message(message.channel, "Pokemon GO roles don't exist on the server.")
 
-        stats_message = '''
-        Team stats for {0}
-        Users on Team Mystic: {1} ({4:.2f}%)
-        Users on Team Valor: {2} ({5:.2f}%)
-        Users on Team Instinct: {3} ({6:.2f}%)
-        '''
-
         # TODO: Make this work with the new server team list
 
         role_stats = {
@@ -390,7 +389,7 @@ async def on_message(message):
                     role_stats[role.name] += 1
                     total += 1
 
-        msg = stats_message.format(
+        msg = messages.stats_message.format(
             message.server.name,
             role_stats["Mystic"],
             role_stats["Valor"],

--- a/bot.py
+++ b/bot.py
@@ -356,13 +356,17 @@ async def on_message(message):
         if utils.check_perms(message):
             server_obj = bot.get_server(server=message.server)
             if server_obj.remove_custom_role(message):
-                await client.send_message(message.channel, "Role `{}` can now not be added with %team.".format(message.content[14:]))
+                await client.send_message(message.channel, "Role `{}` now can *not* be added with %team.".format(message.content[14:]))
             else:
                 await client.send_message(message.channel, "Role `{}` was already not assignable.".format(message.content[14:]))
 
     # Team stats in the server. Only for pokemon go servers
 
     elif message.content.startswith('%stats'):
+
+        server_obj = bot.servers[message.server.id]
+        if not server_obj.exists_default_roles():
+            await client.send_message(message.channel, "Pokemon GO roles don't exist on the server.")
 
         stats_message = '''
         Team stats for {0}
@@ -415,5 +419,6 @@ async def on_message(message):
                 await client.send_message(default_channel, message.content[9:])
                 sleep(0.5)  # To be nice on the api
 
+print("Logging in...")
 
 client.run(auth["token"])

--- a/bot.py
+++ b/bot.py
@@ -172,7 +172,7 @@ async def on_message(message):
         elif (not server_obj.check_role(entered_team)) or (role is None):
             # If the role wasn't found by discord.utils.get() or is a role that we don't want to add, such as it not
             # being in the roles list:
-            await client.send_message(message.channel, "Role isn't addable;" + server_obj.list_roles())
+            await client.send_message(message.channel, "Role isn't addable; " + server_obj.list_roles())
 
         elif role in member.roles:
             # If they already have the role
@@ -265,7 +265,7 @@ async def on_message(message):
             server_obj = bot.servers[message.server.id]
             server_obj.pm_config = flag_prefs[flag]
             server_obj.export_to_file()
-            await client.send_message(message.channel, "Server PM preferences now set to {0}.".format(flag_prefs[flag]))
+            await client.send_message(message.channel, "Server PM preferences now set to {0}.".format(flag))
 
     # TODO: Add server config command that handles %pm and %role_config
 
@@ -285,9 +285,9 @@ async def on_message(message):
                                           "%role_\config [exclusive/multiple]__*: Setting to exclusive (default) only allows one role to be set per user. Setting to multiple allows users to set as many roles as they want.")
                 return
             server_obj = bot.servers[message.server.id]
-            server_obj.pm_config = flag_prefs[flag]
+            server_obj.exclusive = flag_prefs[flag]
             server_obj.export_to_file()
-            await client.send_message(message.channel, "Server role preferences now set to {0}.".format(flag_prefs[flag]))
+            await client.send_message(message.channel, "Server role preferences now set to {0}.".format(flag))
 
     # Small command listing information on the server itself.
 
@@ -335,7 +335,7 @@ async def on_message(message):
                 await client.create_role(message.server, name="Valor", color=discord.Color.red(),
                                          permissions=utils.team_perms, position=2)
                 await client.send_message(message.channel, "Blank roles successfully added.")
-                server_obj.init_default_roles()
+                server_obj.init_default_roles(message)
             except discord.Forbidden:
                 await client.send_message(message.channel, "I don't have the `Manage Roles` permission.")
                 return

--- a/bot.py
+++ b/bot.py
@@ -147,7 +147,11 @@ async def on_message(message):
                     # TODO: Fix possibility of IndexError
 
             member = discord.utils.get(server.members, id=message.author.id)
-            server_obj = bot.servers[server.id]
+            try:
+                server_obj = bot.servers[server.id]
+            except KeyError:  # Datafile is missing or something, it's not there.
+                await client.send_message(message.channel, "The server datafile appears to be nonexistent for some reason.")
+                return
 
         # Now, actually handle and process the roles.
 

--- a/bot.py
+++ b/bot.py
@@ -102,7 +102,7 @@ async def on_message(message):
             pm_prefs = int(server_obj.pm_config)
 
             if pm_prefs == 1:  # Server owner has required roles be set by PMs.
-                await client.send_message(message.channel, "The server owner has required that roles be set by PM.")
+                await client.send_message(message.channel, "The server moderators have required that roles be set by PM.")
                 return
             elif whitelist is not None:  # The channel was not in the whitelist.
                 await client.send_message(message.channel, whitelist)
@@ -372,7 +372,7 @@ async def on_message(message):
 
         server_obj = bot.servers[message.server.id]
         if not server_obj.exists_default_roles():
-            await client.send_message(message.channel, "Pokemon GO roles don't exist on the server.")
+            await client.send_message(message.channel, "This command requires Pokemon GO roles, which don't exist on this server.")
 
         # TODO: Make this work with the new server team list
 
@@ -413,9 +413,9 @@ async def on_message(message):
 
     elif message.content.startswith("%announce"):
         if bot.sudo(message):
-            for server_id, server in bot.servers:
-                default_channel = discord.utils.find(lambda c: c.is_default, server.channels)
-                await client.send_message(default_channel, message.content[9:])
+            for server_id, server in bot.servers.items():
+                default_channel = discord.utils.get(server.obj.channels, is_default=True)
+                await client.send_message(default_channel, message.content[10:])
                 sleep(0.5)  # To be nice on the api
 
 print("Logging in...")

--- a/bot.py
+++ b/bot.py
@@ -94,7 +94,7 @@ async def on_message(message):
 
         if not message.channel.is_private:  # Not a PM.
 
-            server_obj = bot.servers[message.server.id]  # TODO: is it possible to just do bot.servers(id=message.server.id)?
+            server_obj = bot.servers[message.server.id]
 
             # Run checks to see if the message should go through or not
 
@@ -170,7 +170,7 @@ async def on_message(message):
             # Role does not exist on the server, but is in the team_list, so the server just isn't configured properly.
             await client.send_message(message.channel,
                                       "The role you're trying to add existed at some point, but does not anymore, or has since been renamed.")
-            # TODO: Consider using IDs in self.roles for this very reason!
+            # TODO: Consider using IDs in self.roles for this very reason
 
         elif (not server_obj.check_role(entered_team)) or (role is None):
             # If the role wasn't found by discord.utils.get() or is a role that we don't want to add, such as it not
@@ -269,8 +269,6 @@ async def on_message(message):
             server_obj.pm_config = flag_prefs[flag]
             server_obj.export_to_file()
             await client.send_message(message.channel, "Server PM preferences now set to {0}.".format(flag))
-
-    # TODO: Add server config command that handles %pm and %role_config
 
     elif message.content.startswith("%role_config"):
         if not utils.check_perms(message):
@@ -374,8 +372,6 @@ async def on_message(message):
         if not server_obj.exists_default_roles():
             await client.send_message(message.channel, "This command requires Pokemon GO roles, which don't exist on this server.")
 
-        # TODO: Make this work with the new server team list
-
         role_stats = {
             "Mystic": 0,
             "Valor": 0,
@@ -394,7 +390,7 @@ async def on_message(message):
             role_stats["Mystic"],
             role_stats["Valor"],
             role_stats["Instinct"],
-            utils.get_percentage(role_stats["Mystic"], total),  # TODO: This throws a divide by zero error
+            utils.get_percentage(role_stats["Mystic"], total),
             utils.get_percentage(role_stats["Valor"], total),
             utils.get_percentage(role_stats["Instinct"], total)
         )

--- a/bot.py
+++ b/bot.py
@@ -403,6 +403,17 @@ async def on_message(message):
         if bot.sudo(message):
             await client.send_message(message.channel, eval(message.content[6:]))
 
+    # Set bot status, or "game" it's currently playing.
+    # A blank message removes the status
+
+    elif message.content.startswith('%status'):
+        if bot.sudo(message):
+            if message.content[8:] != "":
+                game_name = message.content[8:]
+            else:
+                game_name = None
+            await client.change_status(game=discord.Game(name=game_name))
+
     # !!!!!!!!
     # SENDS A MESSAGE TO EVERY SERVER CONNECTED TO THE BOT. NOT AN ECHO COMMAND.
     # NOT TO BE TAKEN LIGHTLY, AND I RECOMMEND YOU DON'T USE @everyone IN THE MESSAGE UNLESS YOU WANT HATE MAIL

--- a/bot.py
+++ b/bot.py
@@ -67,7 +67,11 @@ async def on_server_join(server):
     bot.add_new_server(client, server)
     await client.send_message(server.owner, owner_message)
 
-# TODO: Add on_server_leave event
+
+@client.event
+async def on_server_remove(server):
+    print("Left {}".format(server.name))
+    bot.remove_server(server)
 
 
 @client.event

--- a/bot.py
+++ b/bot.py
@@ -54,7 +54,8 @@ bot = utils.Bot(client)
 async def on_ready():
     bot.initializing = True  # TODO: Create exceptions on message if bot.initializing == True
     print("Initializing server data...")
-    bot.servers = utils.init(client)  # Load the server datafiles, create objects. I frankly don't know how long this will take.
+    bot.init(client)  # Load the server datafiles, create objects. I frankly don't know how long this will take.
+    #bot.update_datafiles(client)
     print("Done.")
     bot.initializing = False
     print('Logged in as')
@@ -159,7 +160,7 @@ async def on_message(message):
                 await client.send_message(message.channel,
                                           "You already have a team role. If you want to switch, message a moderator.")
                 return
-
+        # TODO: Make this check based on whether or not the server has used default roles
         if (server_obj.check_role(entered_team)) & (role is None):
             # Role does not exist on the server, but is in the team_list, so the server just isn't configured properly.
             await client.send_message(message.channel,

--- a/bot.py
+++ b/bot.py
@@ -240,14 +240,14 @@ async def on_message(message):
         if utils.check_perms(message):
             server_obj = bot.servers[message.server.id]
             if message.channel.id in server_obj.channel_whitelist:
-                await client.send_message(message.channel, "This channel is already whitelisted.")
-            else:
                 with open("server_data/{0}.json".format(message.server.id), "r", encoding="utf-8") as tmp:
                     temp_data = json.load(tmp)
                     temp_data["team_ch_wl"].remove(message.channel.id)
                 with open("server_data/{0}.json".format(message.server.id), "w", encoding="utf-8") as tmp:
                     json.dump(temp_data, tmp)
-                    await client.send_message(message.channel, "Channel successfully removed from the whitelist.")
+                await client.send_message(message.channel, "Channel successfully removed from the whitelist.")
+            else:
+                await client.send_message(message.channel, "This channel is not whitelisted.")
 
     # Adjust server PM preferences
 

--- a/bot.py
+++ b/bot.py
@@ -73,6 +73,8 @@ async def on_server_join(server):
 @client.event
 async def on_message(message):
 
+    # TODO: Make a call for the server object here
+
     if message.author.id == client.user.id:
         return
 
@@ -97,24 +99,15 @@ async def on_message(message):
 
             # Run checks to see if the message should go through or not
 
-            whitelist = server_obj.whitelist
-            pm_prefs = server_obj.pm_config
+            whitelist = server_obj.check_whitelist(message)
+            pm_prefs = int(server_obj.pm_config)
 
-            if whitelist is None:  # Nothing in the whitelist, needs to come first
-                pass
-            elif pm_prefs == 1:  # Server owner has required roles be set by PMs.
+            if pm_prefs == 1:  # Server owner has required roles be set by PMs.
                 await client.send_message(message.channel, "The server owner has required that roles be set by PM.")
                 return
-            elif message.channel.id not in whitelist:  # Whitelist exists, and this channel's not in it
-                if len(whitelist) == 1:
-                    await client.send_message(message.channel, "Please put team requests in <#{0}>.".format(whitelist[0]))
-                    return
-                elif len(whitelist) > 1:  # Grammar for grammar's sake, any more are ignored.
-                    await client.send_message(message.channel,
-                                              "Please put team requests in <#{0}> or <#{1}>.".format(whitelist[0], whitelist[1]))
-                    return
-            else:
-                pass
+            elif whitelist is not None:  # The channel was not in the whitelist.
+                await client.send_message(message.channel, whitelist)
+                return
 
             member = message.author
             server = message.server
@@ -325,6 +318,10 @@ async def on_message(message):
     # Team stats in the server.
 
     elif message.content.startswith('%stats'):
+
+
+        # TODO: Make this work with the new server team list
+
         role_stats = {
             "Mystic": 0,
             "Valor": 0,
@@ -342,7 +339,7 @@ async def on_message(message):
             role_stats["Mystic"],
             role_stats["Valor"],
             role_stats["Instinct"],
-            ((role_stats["Mystic"] / role_stats["total"]) * 100),
+            ((role_stats["Mystic"] / role_stats["total"]) * 100), # TODO: This throws a divide by zero error
             ((role_stats["Valor"] / role_stats["total"]) * 100),
             ((role_stats["Instinct"] / role_stats["total"]) * 100),
         )

--- a/bot.py
+++ b/bot.py
@@ -143,7 +143,11 @@ async def on_message(message):
                     await client.send_message(message.channel, "That number was too large, try %team again.")
                     return
                 else:
-                    server = servers_shared[(int(server_selection) - 1)]
+                    try:
+                        server = servers_shared[(int(server_selection) - 1)]
+                    except IndexError:
+                        await client.send_message(message.channel, "That number was too large, try %team again.")
+                        return
                     # TODO: Fix possibility of IndexError
 
             member = discord.utils.get(server.members, id=message.author.id)

--- a/config_default.json
+++ b/config_default.json
@@ -1,3 +1,4 @@
 {
-  "owner_id": "[Add your user ID Here]"
+  "owner_id": "[Add your user ID Here]",
+  "info-message": "[Add text for %info command here]"
 }

--- a/messages.py
+++ b/messages.py
@@ -1,19 +1,20 @@
 # Command list, called with %help or %commands
 
 help_message = '''
-__%team [team name]__: Assign yourself to a team. Typed like `%team Mystic` to set your role as Team Mystic.\n
-__%whitelist\*__: Set a specific channel for team setting.\n
-__%unwhitelist__\*: Re-allow team setting in a channel.\n
-__%server_info__: Output a small list of information about the server.\n
-__%help or %commands__: Show this message again.\n
-__%pm [required/optional]__\*: Optional is default, and required disables setting roles in the server.\n
-__%invite__: Generate a link that you can use to add goPC to your own server.\n
+**%team [team name]**: Assign yourself to a team. Typed like `%team Mystic` to set your role as Team Mystic.\n
+**%whitelist**\*: Set a specific channel for team setting.\n
+**%unwhitelist**\*: Re-allow team setting in a channel.\n
+**%server_info**: Output a small list of information about the server.\n
+**%help or %commands**: Show this message again.\n
+**%pm [required/optional]**\*: Optional is default, and required disables setting roles in the server.\n
+**%invite**: Generate a link that you can use to add goPC to your own server.\n
 **%create_roles**\*: Create three empty team roles that goPC can use to assign.\n
-__%stats__: List stats on the number of team members, including the percentage of the members on each team.\n
-__%wiki [page]__: Find a page on bulbapedia.\n
-__%add_assignable_role [role name]__: Allow a role to be added by goPC.
-__%role_config [exclusive/multiple]__\*: Setting to exclusive (default) only allows one role to be set per user. Setting to multiple allows users to set as many roles as they want.
-**Commands with an asterisk can only be run by the server owner or a user with the `Manage Server` permission.**
+**%stats**: List stats on the number of team members, including the percentage of the members on each team. Note that this only works for Pokemon GO teams that use the default format.\n
+**%wiki [page]**: Find a page on bulbapedia.\n
+**%enable_role [role name]**\*: Allow a role to be added by goPC.
+**%disable_role [role name]**\*: Disallow a role from being added by goPC, if it already can be.
+**%role_config [exclusive/multiple]**\*: Setting to exclusive (default) only allows one role to be set per user. Setting to multiple allows users to set as many roles as they want.
+**Commands with an asterisk (\*) can only be run by the server owner or a user with the `Manage Server` permission.**
 '''
 
 # Owner message, sent to the owner when connecting to a server

--- a/messages.py
+++ b/messages.py
@@ -1,19 +1,19 @@
 # Command list, called with %help or %commands
 
 help_message = '''
-**%team [team name]**: Assign yourself to a team. Typed like `%team Mystic` to set your role as Team Mystic.\n
-**%whitelist**\*: Set a specific channel for team setting.\n
-**%unwhitelist**\*: Re-allow team setting in a channel.\n
-**%server_info**: Output a small list of information about the server.\n
-**%help or %commands**: Show this message again.\n
-**%pm [required/optional]**\*: Optional is default, and required disables setting roles in the server.\n
-**%invite**: Generate a link that you can use to add goPC to your own server.\n
-**%create_roles**\*: Create three empty team roles that goPC can use to assign.\n
-**%stats**: List stats on the number of team members, including the percentage of the members on each team. Note that this only works for Pokemon GO teams that use the default format.\n
-**%wiki [page]**: Find a page on bulbapedia.\n
+**%team [team name]**: Assign yourself to a team. Typed like `%team Mystic` to set your role as Team Mystic.
+**%whitelist**\*: Set a specific channel for team setting.
+**%unwhitelist**\*: Re-allow team setting in a channel.
+**%server_info**: Output a small list of information about the server.
+**%help or %commands**: Show this message again.
+**%pm [required/optional]**\*: Optional is default, and required disables setting roles in the server.
+**%invite**: Generate a link that you can use to add goPC to your own server.
+**%create_roles**\*: Create three empty team roles that goPC can use to assign.
+**%stats**: List stats on the number of team members, including the percentage of the members on each team. Note that this only works for Pokemon GO teams that use the default format.
+**%wiki [page]**: Find a page on bulbapedia.
 **%enable_role [role name]**\*: Allow a role to be added by goPC.
 **%disable_role [role name]**\*: Disallow a role from being added by goPC, if it already can be.
-**%role_config [exclusive/multiple]**\*: Setting to exclusive (default) only allows one role to be set per user. Setting to multiple allows users to set as many roles as they want.
+**%role_config [exclusive/multiple]**\*: Setting to exclusive (default) only allows one role to be set per user. Setting to multiple allows users to set as many roles as they want.\n
 **Commands with an asterisk (\*) can only be run by the server owner or a user with the `Manage Server` permission.**
 '''
 

--- a/messages.py
+++ b/messages.py
@@ -12,7 +12,7 @@ __%invite__: Generate a link that you can use to add goPC to your own server.\n
 __%stats__: List stats on the number of team members, including the percentage of the members on each team.\n
 __%wiki [page]__: Find a page on bulbapedia.\n
 __%add_assignable_role [role name]__: Allow a role to be added by goPC.
-__%role_\config [exclusive/multiple]__*: Setting to exclusive (default) only allows one role to be set per user. Setting to multiple allows users to set as many roles as they want.
+__%role_config [exclusive/multiple]__\*: Setting to exclusive (default) only allows one role to be set per user. Setting to multiple allows users to set as many roles as they want.
 **Commands with an asterisk can only be run by the server owner or a user with the `Manage Server` permission.**
 '''
 

--- a/messages.py
+++ b/messages.py
@@ -2,11 +2,11 @@
 
 help_message = '''
 **%team [team name]**: Assign yourself to a team. Typed like `%team Mystic` to set your role as Team Mystic.
-**%whitelist**\*: Set a specific channel for team setting.
-**%unwhitelist**\*: Re-allow team setting in a channel.
+**%whitelist**\*: Make %team only work in the channel(s) this is called in.
+**%unwhitelist**\*: Remove the channel this is called in from the whitelist.
 **%server_info**: Output a small list of information about the server.
 **%help or %commands**: Show this message again.
-**%pm [required/optional]**\*: Optional is default, and required disables setting roles in the server.
+**%pm [required/optional]**\*: Optional is default, and lets you call %team in the server as well as PMs, while required disables setting roles in the server.
 **%invite**: Generate a link that you can use to add goPC to your own server.
 **%create_roles**\*: Create three empty Pokemon GO team roles that goPC can use to assign.
 **%stats**: List stats on the number of team members, including the percentage of the members on each team. Note that this only works for Pokemon GO teams that use the default format.
@@ -24,9 +24,9 @@ owner_message = '''
 Hi, thanks for adding me to your server!
 In case you weren't aware, I'm a role managing bot. Assuming proper role setup, posting __%team__ followed by a designated role name will add the role to a user automatically. By default, I work with the role names `Valor`, `Mystic`, and `Instinct`, but of course only if the roles actually exist on the server. You (or someone with the Manage Server permission) can type **%enable_role [role name]** to enable adding that role with %team.
 
-Adding roles works within server channels, as well as in PMs. If you want to specify a channel that people can set roles in, type __%whitelist__ in said channel.
+Adding roles works within server channels, as well as in PMs. If you want to specify a channel that people can set roles in, type __%whitelist__ in said channel, and it'll direct role assignments to that channel.
 
-Otherwise, users can just PM me with %team, and it will work even if we share multiple servers. If you want users to only be able to assign roles via PMs, post __%pm required__ in the server.
+Otherwise, users can just use %team in a PM, and it will work even if we share multiple servers. If you want users to only be able to assign roles via PMs, post __%pm required__ in the server.
 
 If you would just like me to create default Pokemon GO roles, someone with the Manage Server permission (or you, the owner) can type **%create_roles** in the server, and I will create empty template roles for Pokemon GO teams, which I can then assign.
 

--- a/messages.py
+++ b/messages.py
@@ -1,0 +1,38 @@
+# lol fuck good practices
+
+# Command list, called with %help or %commands
+
+help_message = '''
+__%team [team name]__: Assign yourself to a team. Typed like `%team Mystic` to set your role as Team Mystic.\n
+__%whitelist\*__: Set a specific channel for team setting.\n
+__%unwhitelist__\*: Re-allow team setting in a channel.\n
+__%server_info__: Output a small list of information about the server.\n
+__%help or %commands__: Show this message again.\n
+__%pm [required/optional]__\*: Optional is default, and required disables setting roles in the server.\n
+__%invite__: Generate a link that you can use to add goPC to your own server.\n
+__%create_roles__\*: Create three empty team roles that goPC can use to assign.\n
+__%stats__: List stats on the number of team members, including the percentage of the members on each team.\n
+__%wiki [page]__: Find a page on bulbapedia.\n
+**Commands with an asterisk can only be run by the server owner or a user with the `Manage Server` permission.**
+'''
+
+# Owner message, sent to the owner when connecting to a server
+
+owner_message = '''
+Hi, thanks for adding me to your server!
+In case you weren't aware, I'm a role managing bot. Assuming proper role setup, posting __%team__ followed by `Instinct`, `Valor`, or `Mystic` will add a role to a user automatically.
+
+This should work in a channel within the server, as well as in PMs. If you want to specify a channel that people can set roles in, type __%whitelist__ in said channel.
+
+Otherwise, users can just PM me with %team, and it will work even if we share multiple servers. If you want users to only be able to assign roles via PMs, post __%pm required__.
+
+If you would like me to create roles, someone with the Manage Server permission (or you, the owner) can type __%create_roles__ in the server, and I will create empty template roles for the server that work with me.
+
+Regardless, in order for me to work, the role names should be `Valor`, `Mystic`, and `Instinct` (case sensitive), and users should call %team with those exact parameters.
+
+**The team roles *need* to be located below goPC's role in order for them to be able to be assigned, or else it will say it does not have permissions.**
+
+My code base is available at https://github.com/chafla/SomebodysPC.
+If you have any questions, problems, compliments, etc., you can find `Luc | ルカリオ#5653` (my writer) in the /r/PokemonGO server.
+'''
+

--- a/messages.py
+++ b/messages.py
@@ -8,12 +8,13 @@ help_message = '''
 **%help or %commands**: Show this message again.
 **%pm [required/optional]**\*: Optional is default, and required disables setting roles in the server.
 **%invite**: Generate a link that you can use to add goPC to your own server.
-**%create_roles**\*: Create three empty team roles that goPC can use to assign.
+**%create_roles**\*: Create three empty Pokemon GO team roles that goPC can use to assign.
 **%stats**: List stats on the number of team members, including the percentage of the members on each team. Note that this only works for Pokemon GO teams that use the default format.
 **%wiki [page]**: Find a page on bulbapedia.
 **%enable_role [role name]**\*: Allow a role to be added by goPC.
 **%disable_role [role name]**\*: Disallow a role from being added by goPC, if it already can be.
-**%role_config [exclusive/multiple]**\*: Setting to exclusive (default) only allows one role to be set per user. Setting to multiple allows users to set as many roles as they want.\n
+**%role_config [exclusive/multiple]**\*: Setting to exclusive (default) only allows one role to be set per user. Setting to multiple allows users to set as many roles as they want.
+**%server_config**: Output the current server settings (whitelisted channels, role config, addable roles, and PM settings).\n
 **Commands with an asterisk (\*) can only be run by the server owner or a user with the `Manage Server` permission.**
 '''
 
@@ -21,19 +22,24 @@ help_message = '''
 
 owner_message = '''
 Hi, thanks for adding me to your server!
-In case you weren't aware, I'm a role managing bot. Assuming proper role setup, posting __%team__ followed by a designated role name will add the role to a user automatically. By default, I work with the role names `Valor`, `Mystic`, and `Instinct`, but of course only if the roles actually exist.
+In case you weren't aware, I'm a role managing bot. Assuming proper role setup, posting __%team__ followed by a designated role name will add the role to a user automatically. By default, I work with the role names `Valor`, `Mystic`, and `Instinct`, but of course only if the roles actually exist on the server. You (or someone with the Manage Server permission) can type **%enable_role [role name]** to enable adding that role with %team.
 
-This should work in a channel within the server, as well as in PMs. If you want to specify a channel that people can set roles in, type __%whitelist__ in said channel.
+Adding roles works within server channels, as well as in PMs. If you want to specify a channel that people can set roles in, type __%whitelist__ in said channel.
 
-Otherwise, users can just PM me with %team, and it will work even if we share multiple servers. If you want users to only be able to assign roles via PMs, post __%pm required__.
+Otherwise, users can just PM me with %team, and it will work even if we share multiple servers. If you want users to only be able to assign roles via PMs, post __%pm required__ in the server.
 
-If you would just like me to create roles, someone with the Manage Server permission (or you, the owner) can type **%create_roles** in the server, and I will create empty template roles for Pokemon GO teams.
-
-Regardless, in order for me to work, the role names should be `Valor`, `Mystic`, and `Instinct` (case sensitive), and users should call %team with those exact parameters.
+If you would just like me to create default Pokemon GO roles, someone with the Manage Server permission (or you, the owner) can type **%create_roles** in the server, and I will create empty template roles for Pokemon GO teams, which I can then assign.
 
 **The team roles *need* to be located below goPC's role in order for them to be able to be assigned, or else it will say it does not have permissions.**
 
-My code base is available at https://github.com/chafla/SomebodysPC.
+My code base, as well as some more information on what I can do, is available at https://github.com/chafla/SomebodysPC.
 If you have any questions, problems, compliments, etc., you can find `Luc | ルカリオ#5653` (my writer) in the /r/PokemonGO server.
+'''
+
+stats_message = '''
+Pokémon GO team stats for {0}
+Users on Team Mystic: {1} ({4:.2f}%)
+Users on Team Valor: {2} ({5:.2f}%)
+Users on Team Instinct: {3} ({6:.2f}%)
 '''
 

--- a/messages.py
+++ b/messages.py
@@ -1,5 +1,3 @@
-# lol fuck good practices
-
 # Command list, called with %help or %commands
 
 help_message = '''
@@ -10,9 +8,11 @@ __%server_info__: Output a small list of information about the server.\n
 __%help or %commands__: Show this message again.\n
 __%pm [required/optional]__\*: Optional is default, and required disables setting roles in the server.\n
 __%invite__: Generate a link that you can use to add goPC to your own server.\n
-__%create_roles__\*: Create three empty team roles that goPC can use to assign.\n
+**%create_roles**\*: Create three empty team roles that goPC can use to assign.\n
 __%stats__: List stats on the number of team members, including the percentage of the members on each team.\n
 __%wiki [page]__: Find a page on bulbapedia.\n
+__%add_assignable_role [role name]__: Allow a role to be added by goPC.
+__%role_\config [exclusive/multiple]__*: Setting to exclusive (default) only allows one role to be set per user. Setting to multiple allows users to set as many roles as they want.
 **Commands with an asterisk can only be run by the server owner or a user with the `Manage Server` permission.**
 '''
 
@@ -20,13 +20,13 @@ __%wiki [page]__: Find a page on bulbapedia.\n
 
 owner_message = '''
 Hi, thanks for adding me to your server!
-In case you weren't aware, I'm a role managing bot. Assuming proper role setup, posting __%team__ followed by `Instinct`, `Valor`, or `Mystic` will add a role to a user automatically.
+In case you weren't aware, I'm a role managing bot. Assuming proper role setup, posting __%team__ followed by a designated role name will add the role to a user automatically. By default, I work with the role names `Valor`, `Mystic`, and `Instinct`, but of course only if the roles actually exist.
 
 This should work in a channel within the server, as well as in PMs. If you want to specify a channel that people can set roles in, type __%whitelist__ in said channel.
 
 Otherwise, users can just PM me with %team, and it will work even if we share multiple servers. If you want users to only be able to assign roles via PMs, post __%pm required__.
 
-If you would like me to create roles, someone with the Manage Server permission (or you, the owner) can type __%create_roles__ in the server, and I will create empty template roles for the server that work with me.
+If you would just like me to create roles, someone with the Manage Server permission (or you, the owner) can type **%create_roles** in the server, and I will create empty template roles for Pokemon GO teams.
 
 Regardless, in order for me to work, the role names should be `Valor`, `Mystic`, and `Instinct` (case sensitive), and users should call %team with those exact parameters.
 

--- a/utils.py
+++ b/utils.py
@@ -3,8 +3,6 @@ import discord
 import sys
 from os import listdir, remove
 
-# TODO: Run this at start of program, after on ready but make sure there's a flag that doesn't let commands be handled while it's still initializing, possibly in Bot
-
 
 class Bot:
 
@@ -110,9 +108,11 @@ class Server:
         self.exclusive = data["exclusive"]
         self.obj = discord.utils.get(client.servers, id=self.id)  # Needs to be called here and not __init__() for some reason
 
-    def update_data_files(self, client, datafile_path, server_id):
+    def update_data_files(self, client, datafile_path, datafile_filename):
         # Utility to update all existing datafiles in case I add new stuff to dicts.
         # Mostly hardcoded, and requires that the client connect in the first place.
+        # To use, add the new keys to test_var.
+        server_id = datafile_filename[:-5]
         with open(datafile_path, "r", encoding="utf-8") as tmp:
             data = json.load(tmp)
         try:
@@ -121,13 +121,13 @@ class Server:
         except KeyError:
             with open(datafile_path, "r", encoding="utf-8") as tmp:
                 data = json.load(tmp)
-            server = discord.utils.get(client.servers, id=server_id[:-5])
+            server = discord.utils.get(client.servers, id=server_id)
 
             if server is None:
                 # This means that we don't belong to the server for some reason. Throws AttributeErrors.
                 # Just reformat the file so that we don't get errors.
                 self.name = ""
-                self.id = server_id[:-5]
+                self.id = server_id
                 self.roles = []
                 self.exclusive = "0"
                 self.export_to_file()

--- a/utils.py
+++ b/utils.py
@@ -186,13 +186,13 @@ class Server:
             json.dump(data, tmp)
 
     def add_custom_role(self, message, external_role=None):
-        # TODO: Occasionally omits the role from the role list. Find out why.
+        # TODO: Occasionally omits the role from the role list. Probably from failing to write to the file for some reason.
         # initialize a custom role that can be added through %team. Server dependent.
-        # If external_role is not None, then it's being called by something else, and we're just passing in the names we know.
+        # If external_role is not None, then it's being called by something that's not the command, and we're just passing in the names we know.
         if external_role is not None:
             role_name = external_role
         else:
-            role_name = message.content[21:]
+            role_name = message.content[13:]
         role = discord.utils.get(message.server.roles, name=role_name)
         if role is None:
             return None
@@ -200,6 +200,21 @@ class Server:
             self.roles.append(role.name)
             self.export_to_file()
             return role
+
+    def remove_custom_role(self, message, external_role=None):
+        # Remove a role from the server object's role list.
+        # Returns True if it succeeds, or False if not.
+        if external_role is not None:
+            role_name = external_role
+        else:
+            role_name = message.content[14:]
+        try:
+            self.roles.remove(role_name)
+            self.export_to_file()
+            return True
+        except IndexError:
+            return False
+
 
     async def check_whitelist(self, message):
         """
@@ -218,7 +233,7 @@ class Server:
                 return "Please put team requests in <#{0}> or <#{1}>.".format(self.channel_whitelist[0], self.channel_whitelist[1])
 
     def get_role_from_server(self, role_name, message, client):
-        # TODO: FINISH THIS
+        # TODO: Set this up to basically handle most of the code in the %rank command
         """
 
         :param role_name: String that contains a name of a role. Should be passed in by message.content[6:]
@@ -254,6 +269,7 @@ class Server:
             return True
 
     def _exists_default_roles(self):
+        # Check to see if default roles exist or not.
         for role in self.obj.roles:
             if role.name in self.base_roles:  # Just assume that if one role exists, then they all do.
                 return True
@@ -338,6 +354,14 @@ def check_perms(message):
                 return True
         else:
             return False
+
+
+def get_percentage(amount, total):
+    if amount > 0:
+        percentage = (amount / total) * 100
+        return percentage
+    else:
+        return amount  # Avoiding div by zero
 
 init_server_datafile = {
     "server_name": "",  # Server name, ofc subject to change.

--- a/utils.py
+++ b/utils.py
@@ -62,7 +62,6 @@ class Bot:
         self.servers.pop(server.id)
 
 
-
     @staticmethod
     def update_datafiles(client):
         datafiles = listdir("server_data/")
@@ -82,9 +81,6 @@ class Server:
     Planned to be used in a future implementation, but currently non-functional.
 
     """
-
-    # TODO: Implement this so that this can be used for multiple servers
-    # TODO: Consider removing self.teams, or even self.default_roles
 
     base_roles = ["Instinct", "Valor", "Mystic"]
 
@@ -168,14 +164,11 @@ class Server:
         output = init_server_datafile
         output["server_id"] = server.id
         output["server_name"] = server.name
-        # TODO: This creates roles with the init datafile, but that doesn't have server ID.
         with open("server_data/{0}.json".format(self.id), "w", encoding="utf-8") as tmp:
             json.dump(output, tmp)
 
     def export_to_file(self):
         # Take the current server object as it is and push it to a .json file.
-
-        # TODO: This might result in problems if multiple people call it at once, but we need it to export.
 
         with open("server_data/{0}.json".format(self.id), "r", encoding="utf-8") as tmp:
             data = json.load(tmp)
@@ -191,7 +184,7 @@ class Server:
             json.dump(data, tmp)
 
     def add_custom_role(self, message, external_role=None):
-        # TODO: Occasionally omits the role from the role list
+        # TODO: Occasionally omits the role from the role list. Find out why.
         # initialize a custom role that can be added through %team. Server dependent.
         # If external_role is not None, then it's being called by something else, and we're just passing in the names we know.
         if external_role is not None:
@@ -300,7 +293,7 @@ class Server:
                     if role not in self.roles or role in self.base_roles:
                         role_list.remove(role)
 
-        base_message = "Roles that can be added with %team are "
+        base_message = "roles that can be added with %team are "
         if len(role_list) == 1:  # If there's only one role addable, make it mostly clean.
             base_message += "`{}`."
         else:

--- a/utils.py
+++ b/utils.py
@@ -1,18 +1,54 @@
 import json
 import discord
 import sys
+from os import listdir
 
-try:
-    with open('config.json', 'r+') as json_config_info:
-        config = json.load(json_config_info)
-except IOError:
-    sys.exit("config.json not found in running directory.")
-
-sudo_list = config["owner"]
+# TODO: Run this at start of program, after on ready but make sure there's a flag that doesn't let commands be handled while it's still initializing, possibly in Bot
 
 
+class Bot:
 
-class ServerPrefs:
+    def __init__(self, client):
+        try:
+            with open('config.json', 'r+') as json_config_info:
+                config = json.load(json_config_info)
+        except IOError:
+            sys.exit("config.json not found in running directory.")
+
+        self.owner_id = config["owner_id"]
+        self.info_message = config["info_message"]
+        self.servers = []
+        self.initializing = False
+        self.client = client
+
+    def sudo(self, message):
+        # Allows for owner-only commands.
+        if message.author.id == self.owner_id:
+            return True
+        else:
+            return False
+
+    def get_server(self, server=None, svr_id=None):
+        if server is not None:
+            return self.servers[server.id]
+        elif svr_id is not None:
+            return self.servers[svr_id]
+
+
+
+
+
+def init(client):  # TODO: Move into Bot()
+    datafiles = listdir("server_data/")
+    server_objs = {}
+    for file in datafiles:
+        server = Server(client)
+        server.init_from_file(file)
+        server_objs[server.id] = server
+    return server_objs
+
+
+class Server:
     """
     Allowing servers to have different roles, and to be able to use different role names.
     Should be called by way of a message, so that we can get all the useful data.
@@ -22,59 +58,135 @@ class ServerPrefs:
     """
 
     # TODO: Implement this so that this can be used for multiple servers
-    def __init__(self, message, role_list, role_message, commanders, default_roles=True):
-        self.roles = {}  # List of server roles, associated with their callable names.
-        self.role_names = []
-        self.message = role_message  # Message to send when a role is added.
-        self.server_whitelist = []
-        self.commanders = []  # People who can adjust server specific settings
-        self.server_id = message.server.id
-        self.server_name = message.server.name
+    # TODO: Consider removing self.teams, or even self.default_roles
 
-        if default_roles:
-            # Allow for people to use the bot for other role-adding purposes.
-            self.teams = ["Instinct", "Valor", "Mystic"]
+    base_roles = ["Instinct", "Valor", "Mystic"]
+
+    def __init__(self, client):
+        self.id = ""
+        self.name = ""
+        self.roles = {}
+        self.channel_whitelist = []
+        self.pm_config = ""
+        self.default_roles = []
+        self.obj = discord.utils.get(client.get_all_servers(), id=self.id)
+
+    # Init on launch, if file has been stored.
+
+    def init_from_file(self, datafile_path):
+        with open(datafile_path, "r", encoding="utf-8") as tmp:
+            data = json.load(tmp)
+        self.id = data["server_id"]
+        self.name = data["server_name"]
+        self.roles = data["custom_roles"]
+        self.channel_whitelist = data["team_ch_wl"]
+        self.pm_config = data["pm"]
+        self.default_roles = data["default_roles"]
+
+    # Initialization on joining server, should be placed in on_server_add
+
+    def init_from_join(self, server):
+        # Kinda roundabout, probably a nicer way to do this
+        self.id = server.id
+        self.name = server.name
+        self.roles = {}
+        self.channel_whitelist = []
+        self.pm_config = "0"
+        self.default_roles = "0"
+
+        with open("server_data/{0}.json".format(self.id), "w", encoding="utf-8") as tmp:
+            json.dump(init_server_datafile, tmp)
+
+    def export_to_file(self):
+
+        # TODO: This might result in problems if multiple people call it at once, but we need it to export.
+
+        with open("server_data/{0}.json".format(self.id), "r", encoding="utf-8") as tmp:
+            data = json.load(tmp)
+
+        data["server_id"] = self.id
+        data["name"] = self.name
+        data["custom_roles"] = self.roles  # List of IDs
+        data["team_ch_wl"] = self.channel_whitelist
+        data["pm"] = self.pm_config
+        data["default_roles"] = self.default_roles
+
+        with open("server_data/{0}.json".format(self.id), "w", encoding="utf-8") as tmp:
+            json.dump(data, tmp)
+
+    def add_custom_role(self, message, external_role=None):
+        # initialize a custom role that can be added through %team. Server dependent.
+        # If external_role is not None, then it's being called by something else, and we're just passing in the names we know.
+        if external_role is not None:
+            role_name = external_role
         else:
-            self.teams = []
-
-    def check_perms(self, message):
-        if message.author.id in self.commanders:
-            return True
+            role_name = message.content[21:]
+        role = discord.utils.get(message.server.roles, name=role_name)
+        if role is None:
+            return None
         else:
-            return False
+            self.roles[role.id] = role.name
+            self.export_to_file()
+            return role
 
-    #def add_bot_commander(self, message, client):
+    def get_role_from_server(self, role_name, message, client):
+        # TODO: FINISH THIS
+        """
 
+        :param role_name: String that contains a name of a role. Should be passed in by message.content[6:]
+        :param message: Message object.
+        :param client: Client object
+        :return:
+        """
+
+        # TODO: Set this up to grab the role object based on context
+        # Get role from server context
+        if message.channel.is_private:
+            member = message.author
+            server = message.server
+            return member, server
+        else:
+            pass
+
+    def init_default_roles(self, message):
+        # To be called when someone calls %create_roles, after the roles have been created successfully.
+        self.default_roles = "1"
+        self.add_custom_role(message, "Valor")
+        self.add_custom_role(message, "Mystic")
+        self.add_custom_role(message, "Instinct")
+        return
+
+    def check_role(self, user_input):
+        # Probably a more efficient way to do this
+        for role_id, role_name in self.roles.items():
+            if role_name == user_input:
+                return True
+        return False
+
+
+
+
+
+
+
+
+
+
+
+    # TODO: Command to create a server when it already exists
 
 async def get_message(client, message, i, base_message):
     msg = await client.wait_for_message(author=message.author, channel=message.channel)
-
     try:
         if 0 < int(msg.content) <= i:
             print(i)
             return int(msg.content)
         else:
-            print("a")
             await client.send_message(message.channel, base_message)
             await get_message(client, message, i, base_message)
     except ValueError:  # In case what they return isn't convertible to an int
-        print("b")
         await client.send_message(message.channel, base_message)
         await get_message(client, message, i, base_message)
-
-
-# TODO: Make a command to run on first launch that loads things from a db or json files or something
-# Run that during on_ready()
-class Bot:
-    pass
-
-
-def sudo(message):
-    # Allows for owner-only commands.
-    if message.author.id in sudo_list:
-        return True
-    else:
-        return False
 
 
 def check_perms(message):
@@ -91,10 +203,11 @@ def check_perms(message):
 
 init_server_datafile = {
     "server_name": "",
-    "team_ch_wl": [],  # channel ids
-    "pm": "0"
-
-
+    "server_id": "",
+    "team_ch_wl": [],  # channel ids where it's allowed
+    "pm": "0",
+    "custom_roles": {},  # role id: role name. useful for
+    "default_roles": "0"  # 0 means default roles don't exist, 1 means that they do.
 }
 
 # Required perms for bot operation. Used for sending an oauth link.

--- a/utils.py
+++ b/utils.py
@@ -129,6 +129,22 @@ class Server:
             self.export_to_file()
             return role
 
+    async def check_whitelist(self, message):
+        """
+        Check against the channel whitelist to see if the command should be allowed in this channel.
+        :param message: message object from context
+        :return: None if the command goes through, otherwise a message detailing why it didn't.
+        """
+        if self.channel_whitelist is None or message.channel.id in self.channel_whitelist:
+            # Command does go through
+            return None
+        elif message.channel.id not in self.channel_whitelist:
+            # Command doesn't go through, return a message on where that should be allowed.
+            if len(self.channel_whitelist) == 1:
+                return "Please put team requests in <#{0}>.".format(self.channel_whitelist[0])
+            elif len(self.channel_whitelist) > 1:  # Grammar for grammar's sake, any more are ignored.
+                return "Please put team requests in <#{0}> or <#{1}>.".format(self.channel_whitelist[0], self.channel_whitelist[1])
+
     def get_role_from_server(self, role_name, message, client):
         # TODO: FINISH THIS
         """
@@ -162,16 +178,6 @@ class Server:
             if role_name == user_input:
                 return True
         return False
-
-
-
-
-
-
-
-
-
-
 
     # TODO: Command to create a server when it already exists
 

--- a/utils.py
+++ b/utils.py
@@ -273,27 +273,6 @@ class Server:
         # TODO: Consider removing this first check because the default role list already doesn't contain the pogo roles.
         # Compile roles into a fancy, readable format.
 
-        # First, check to see if the server only has the default roles added.
-        # If so, we can probably assume that it's either not been set up yet, or that it's only running pogo roles.
-        # As a result, we need to check the existing roles on the server first, to see if it is indeed just pogo roles.
-
-        # This is probably a hack that can be eliminated by just removing the base roles in the first place, but ehh.
-        '''
-        role_list = self.roles
-        # TODO: This hits an error when it's passed a non-existent server object for some reason?
-        if self.exists_default_roles():
-            # If the pogo roles (as in the objects) actually exist on the server, then don't filter them out.
-            # If they don't, then don't let it show them in the list.
-            i = 0
-            for role in self.obj.roles:
-                if role.name in self.base_roles:
-                    i += 1
-            if i < 3:  # They do exist on the server, or at least in limited capacity. Just ignore it
-                for role.name in self.obj.roles:
-                    if role not in self.roles or role in self.base_roles:
-                        role_list.remove(role)
-        '''
-
         role_list = self.roles
 
         base_message = "roles that can be added with %team are "

--- a/utils.py
+++ b/utils.py
@@ -215,7 +215,6 @@ class Server:
         except IndexError:
             return False
 
-
     async def check_whitelist(self, message):
         """
         Check against the channel whitelist to see if the command should be allowed in this channel.
@@ -232,24 +231,7 @@ class Server:
             elif len(self.channel_whitelist) > 1:  # Grammar for grammar's sake, any more are ignored.
                 return "Please put team requests in <#{0}> or <#{1}>.".format(self.channel_whitelist[0], self.channel_whitelist[1])
 
-    def get_role_from_server(self, role_name, message, client):
         # TODO: Set this up to basically handle most of the code in the %rank command
-        """
-
-        :param role_name: String that contains a name of a role. Should be passed in by message.content[6:]
-        :param message: Message object.
-        :param client: Client object
-        :return:
-        """
-
-        # TODO: Set this up to grab the role object based on context
-        # Get role from server context
-        if message.channel.is_private:
-            member = message.author
-            server = message.server
-            return member, server
-        else:
-            pass
 
     def init_default_roles(self, message):
         # To be called when someone calls %create_roles, after the roles have been created successfully.
@@ -268,7 +250,7 @@ class Server:
         else:
             return True
 
-    def _exists_default_roles(self):
+    def exists_default_roles(self):
         # Check to see if default roles exist or not.
         for role in self.obj.roles:
             if role.name in self.base_roles:  # Just assume that if one role exists, then they all do.
@@ -299,7 +281,7 @@ class Server:
         '''
         role_list = self.roles
         # TODO: This hits an error when it's passed a non-existent server object for some reason?
-        if self._exists_default_roles():
+        if self.exists_default_roles():
             # If the pogo roles (as in the objects) actually exist on the server, then don't filter them out.
             # If they don't, then don't let it show them in the list.
             i = 0

--- a/utils.py
+++ b/utils.py
@@ -98,6 +98,8 @@ class Server:
     def init_from_file(self, datafile_path):
 
         # TODO: RE-INITIALIZE ALL EXISTING SERVER OBJECTS WITH THE NEW KEYS
+
+        # TODO: Consider recreating files if they disappear - should really be only needed on manual delete when testing
         # Note: if we do it when the server object is initialized, then we run a risk of it not existing then.
 
         with open(datafile_path, "r", encoding="utf-8") as tmp:
@@ -278,9 +280,9 @@ class Server:
         # As a result, we need to check the existing roles on the server first, to see if it is indeed just pogo roles.
 
         # This is probably a hack that can be eliminated by just removing the base roles in the first place, but ehh.
-
+        '''
         role_list = self.roles
-
+        # TODO: This hits an error when it's passed a non-existent server object for some reason?
         if self._exists_default_roles():
             # If the pogo roles (as in the objects) actually exist on the server, then don't filter them out.
             # If they don't, then don't let it show them in the list.
@@ -292,6 +294,9 @@ class Server:
                 for role.name in self.obj.roles:
                     if role not in self.roles or role in self.base_roles:
                         role_list.remove(role)
+        '''
+
+        role_list = self.roles
 
         base_message = "roles that can be added with %team are "
         if len(role_list) == 1:  # If there's only one role addable, make it mostly clean.

--- a/utils.py
+++ b/utils.py
@@ -49,10 +49,19 @@ class Bot:
             self.servers[server.id] = server
 
     def add_new_server(self, client, server):
+        # Create a new server datafile and object on the fly
         server_obj = Server(client)
         server_obj.init_from_join(server)
         self.servers[server.id] = server_obj
         return
+
+    def remove_server(self, server):
+        # Remove the server datafile and object when leaving a server.
+        print("Removing datafile for {0.name}".format(server))
+        remove("server_data/{0.id}.json".format(server))
+        self.servers.pop(server.id)
+
+
 
     @staticmethod
     def update_datafiles(client):


### PR DESCRIPTION
Lots of big additions here.
# End-user changes
- goPC can now assign server-specific roles: server mods can add other roles to the list that goPC can add, so that they can be added with %team. Pokemon GO roles should still work by default, though.
- Server mods can choose whether to allow users to assign themselves multiple roles, or just one, by using %role_config.
# Behind-the-scenes changes
- **Massive** migration towards use of objects. Every server now has a Server object whose attributes are stored to its json datafile. These files are created upon joining a server, and the objects themselves are created on startup as well as when joining a new server. Lots of functions and other code that used to be in the main bot,py file were also moved within the Server object. One function of special note is export_to_file(), which greatly simplifies the process of updating the datafile based on the object. This should not only result in less I/O, but also massive code simplicity, as well as more possible server-specific features and abilities in the future.

There is also a new Bot object, which holds things such as initializing and other functions, as well as a container for the server objects. Note that `utils.sudo()` was moved to Bot.
- Big changes to the datafile structure, due to addition of three new keys. This means that a retroactive change needs to be run on all existing datafiles, which exists in the form of `Server.update_data_files()`. 
- Messages were reorganized, with some being moved to messages.py. The info message was moved to config.json.
- %announce was added as a bot-owner only command, as well as %status.
- General code cleanup.
